### PR TITLE
vector is now without a capital V.

### DIFF
--- a/CppCodeGenerator.js
+++ b/CppCodeGenerator.js
@@ -734,9 +734,9 @@ define(function (require, exports, module) {
         if (elem.multiplicity) {
             if (_.contains(["0..*", "1..*", "*"], elem.multiplicity.trim())) {
                 if (elem.isOrdered === true) {
-                    _type = "Vector<" + _type + ">";
+                    _type = "vector<" + _type + ">";
                 } else {
-                    _type = "Vector<" + _type + ">";
+                    _type = "vector<" + _type + ">";
                 }
             } else if (elem.multiplicity !== "1" && elem.multiplicity.match(/^\d+$/)) { // number
                 //TODO check here


### PR DESCRIPTION
When having a multiplicity, it used to assign a "Vector". This should not have been a capital V. Made it a small v.